### PR TITLE
Mc!

### DIFF
--- a/cases/story_1/run.jl
+++ b/cases/story_1/run.jl
@@ -23,9 +23,9 @@ model = platform.models[:nameless]
 Scenario(model, (0., 200.)) |> sim |> plot
 scn0 = Scenario(model, (0., 200.))
 sim(scn0, parameters_upd = [:k1=>0.01]) |> plot
-sim(Scenario(model, (0,100)), saveat = 0:10:100) |> plot
-sim(Scenario(model, (0., 50.)), saveat = 0:10:100) |> plot
-sim(Scenario(model, (0., 500.)), saveat = 0:10:100) |> plot
+sim(Scenario(model, (0,100), saveat = 0:10:100)) |> plot
+sim(Scenario(model, (0., 50.), saveat = 0:10:100)) |> plot
+sim(Scenario(model, (0., 500.), saveat = 0:10:100)) |> plot
 Scenario( # throw error
     model, 
     (0., 500.);
@@ -44,12 +44,12 @@ Scenario(
     events_active=[:sw1=>true],
     events_save=[:sw1=>(false,false)]
     ) |> sim |> plot
-sim(Scenario(model, (0., 10.); parameters=[:k1=>1e-3]), parameter_upd = [:k1=>1e-3])
+sim(Scenario(model, (0., 10.); parameters=[:k1=>1e-3]), parameters_upd = [:k1=>1e-3])
 
 ### single scenario sim()
 scn1 = Scenario(model, (0., 200.));
-sim(scn1, saveat = [0.0, 150., 250.]) |> plot
-sim(scn1; saveat = [0.0, 150., 250.], parameters_upd=[:k1=>0.01]) |> plot
+sim(scn1) |> plot
+sim(scn1; parameters_upd=[:k1=>0.01]) |> plot
 
 scn2 = Scenario(
     model,
@@ -78,7 +78,7 @@ sim([:x => scn1, :y=>scn2, :z=>scn3]; parameters_upd=[:k1=>0.01]) |> plot
 #measurements_csv = read_measurements("$HetaSimulatorDir/cases/story_1/measurements.csv")
 measurements_csv = read_measurements("$HetaSimulatorDir/cases/story_1/measurements_no_scope.csv")
 measurements_xlsx = read_measurements("$HetaSimulatorDir/cases/story_1/measurements.xlsx")
-scn4 = Scenario(model, (0,250); parameters = [:k2=>0.001, :k3=>0.04]);
+scn4 = Scenario(model, (0,250); parameters = [:k2=>0.001, :k3=>0.04], saveat = [0.0, 50., 150., 250.]);
 add_measurements!(scn4, measurements_csv; subset = [:scenario => :dataone])
 
 ### fit many scenarios
@@ -87,7 +87,7 @@ res2 = fit([scn2, scn3, scn4], [:k1=>0.1,:k2=>0.2,:k3=>0.3])
 sim(scn3, parameters_upd = optim(res2))
 
 # sim all scenarios
-sol = sim([:c1=>scn1, :c2=>scn2, :c3=>scn3, :c4=>scn4], saveat = [0.0, 50., 150., 250.]);
+sol = sim([:c1=>scn1, :c2=>scn2, :c3=>scn3, :c4=>scn4]);
 plot(sol)
 
 # plot selected observables
@@ -101,12 +101,14 @@ mc_scn1 = Scenario(
     model,
     (0., 200.);
     parameters = [:k1=>0.01],
+    saveat = [50., 80., 150.]
     );
 
 mc_scn2 = Scenario(
     model,
     (0., 200.);
     parameters = [:k1=>0.02],
+    saveat = [50., 100., 200.]
     );
     
 mc_scn3 = Scenario(
@@ -117,15 +119,14 @@ mc_scn3 = Scenario(
     );
 
 # single MC Simulation
-mcsim1 = mc(mc_scn1, [:k1=>Uniform(1e-3,1e-2), :k2=>Normal(1e-3,1e-4), :k3=>Normal(1e-4,1e-5)], 1000, saveat = [50., 80., 150.])
+mcsim1 = mc(mc_scn1, [:k1=>Uniform(1e-3,1e-2), :k2=>Normal(1e-3,1e-4), :k3=>Normal(1e-4,1e-5)], 1000)
 plot(mcsim1)
 
 # multi MC Simulation
 mcsim2 = mc(
     [:mc1=>mc_scn1,:mc2=>mc_scn2,:mc3=>mc_scn3],
     [:k1=>0.01, :k2=>Normal(1e-3,1e-4), :k3=>Uniform(1e-4,1e-2)],
-    1000,
-    saveat = [50., 80., 150.]
+    1000
   )
 plot(mcsim2)
 

--- a/cases/story_2/scenarios.csv
+++ b/cases/story_2/scenarios.csv
@@ -1,5 +1,5 @@
-id,parameters.k1,parameters.k2,parameters.k3,tspan,observables[],events_active.sw1,events_save.sw1
-dataone,,0.001,0.02,150,,,
-withdata2,0.001,,,200,,,
-three,1.00E-03,0.1,,250,,,
-four,1.00E-04,,0.2,1000,b;c,,
+id,parameters.k1,parameters.k2,parameters.k3,saveat[],tspan,observables[],events_active.sw1,events_save.sw1
+dataone,,0.001,0.02,0;12;24;48;72;120,150,,,
+withdata2,0.001,,,0;12;24;48;72;120,,,,
+three,1.00E-03,0.1,,,250,,,
+four,1.00E-04,,0.2,,1000,b;c,,

--- a/cases/story_2/scenarios_w_events.csv
+++ b/cases/story_2/scenarios_w_events.csv
@@ -1,5 +1,5 @@
-id,parameters.k1,parameters.k2,parameters.k3,tspan,observables[],events_active.sw1,events_save.sw1
-dataone,,0.001,0.02,150,,1,1;0
-withdata2,0.001,,,200,,TRUE,true;FALSE
-three,1.00E-03,0.1,,250,,,true;true
-four,1.00E-04,,0.2,1000,b;c,,
+id,parameters.k1,parameters.k2,parameters.k3,saveat[],tspan,observables[],events_active.sw1,events_save.sw1
+dataone,,0.001,0.02,0;12;24;48;72;120,150,,1,1;0
+withdata2,0.001,,,0;12;24;48;72;120,,,TRUE,true;FALSE
+three,1.00E-03,0.1,,,250,,,true;true
+four,1.00E-04,,0.2,,1000,b;c,,

--- a/cases/story_3/run.jl
+++ b/cases/story_3/run.jl
@@ -47,16 +47,13 @@ res_df1 = DataFrame(res[1])
 ### Monte-Carlo
 
 mc_res = mc(p, [:kabs=>Normal(10.,5e-1), :kel=>Normal(0.2,5e-3)], 1000)
-mc_res |> DataFrame # error here
+mc_res |> DataFrame 
 mc_res |> plot
 # plotd = plot(mc_res)
 # savefig(plotd, "sim3.png")
 
 # DataFrame(mc_res[:dose_1])
 # plot(mc_res[:dose_1])
-
-mc_res1 = mc(scenario1, [:kabs=>Normal(10.,5e-1), :kel=>Normal(0.2,5e-3)], 1000, saveat=0.:1.:45.)
-EnsembleSummary(mc_res) |> plot
 
 ### Monte-Carlo for DataFrame
 using DataFrames

--- a/docs/src/table-formats/scenario.md
+++ b/docs/src/table-formats/scenario.md
@@ -16,6 +16,8 @@ The first row is intended for headers which clarify the columns meaning. The seq
 
 - `parameters.<id>` (optional) : a `Float64` value which updates and fixes the value of model's `Const` with the corresponding id. Missing value does not updates the parameter's value and is ignored.
 
+- `saveat[]` (* optional) : a set of `Float64` values separated by semicolons. The values states the time points for simulated output.
+
 - `observables[]` (optional) : a set of `String` separated by semicolon. They state the model records that will be saved as simulation results. If not set the default observables will be used (`output: true` property in Heta notation).
 
 - `events_active.<id>` (optional) : a `Bool` value which updates turns on and off events in model. The `id` is switcher identifier in the Heta. If it is not set the `switcher.active` state from Heta model will be used.
@@ -30,12 +32,12 @@ Scenario table can be loaded into Julia environment as a `DataFrame` using `Heta
 scn_csv = read_scenarios("./scenarios.csv")
 
 4×7 DataFrame
- Row │ id         parameters.k1  parameters.k2  parameters.k3  tspan      observables[] 
-     │ Symbol     Float64?       Float64?       Float64?       Float64?   String?       
+ Row │ id         parameters.k1  parameters.k2  parameters.k3  saveat[]           tspan      observables[] 
+     │ Symbol     Float64?       Float64?       Float64?       String?            Float64?   String?       
 ─────┼─────────────────────────────────────────────────────────────────────────────────────────────────────
-   1 │ dataone     missing               0.001           0.02  150.0      missing       
-   2 │ withdata2         0.001     missing         missing     200.0      missing       
-   3 │ three             0.001           0.1       missing     250.0      missing       
+   1 │ dataone     missing               0.001           0.02  0;12;24;48;72;120      150.0  missing       
+   2 │ withdata2         0.001     missing         missing     0;12;24;48;72;120  missing    missing       
+   3 │ three             0.001           0.1       missing     missing                250.0  missing       
 ```
 
 The data frame can be loaded into platform using the `HetaSimulator.add_scenarios!` method.
@@ -54,11 +56,11 @@ Dict{Symbol, Scenario} with 4 entries:
 
 Loading file __scenarios.csv__ with the following content.
 
-id | model | parameters.k1 | parameters.k2 | parameters.k3 | tspan | observables[] | events_active.sw1 | events_active.sw2 | events_save.sw1
----|---|---|---|---|---|---|---|---|---
-scn1 | | | 0.001 | 0.02 | | | true | false | true;false
-scn2 | nameless | 0.001 | | | 1000 | | | true |
-scn3 | another_model | | 0.001  | | | | false | |
+id | model | parameters.k1 | parameters.k2 | parameters.k3 | saveat[] | tspan | observables[] | events_active.sw1 | events_active.sw2 | events_save.sw1
+--- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---
+scn1 | |  | 0.001 | 0.02 | 0;12;24;48;72;120;150 | | | true | false | true;false
+scn2 | nameless | 0.001 |  |  | |  1000 | | | true |
+scn3 | another_model | | 0.001  |  | 0;12;24;48;72;120 |  | | false |
 
 Read as `DataFrame` object.
 
@@ -81,6 +83,7 @@ scn1 = Scenario(
   platform.models[:nameless],
   (0., 1000.);
   parameters = [:k2=>0.001, :k3=>0.02],
+    saveat = [0, 12, 24, 48, 72, 120, 150],
   events_active = [:sw1=>true, :sw2=>false],
   events_save = [:sw1=>(true,false)]
 )
@@ -98,6 +101,7 @@ scn3 = Scenario(
   platform.models[:another_model],
   (0., 1000.);
   parameters = [:k2=>0.001],
+    saveat = [0, 12, 24, 48, 72, 120],
   events_active = [:sw1=>false]
 )
 push!(platform.scenarios, :scn3=>scn3)

--- a/docs/src/tutorial/mc-files/mc-run.jl
+++ b/docs/src/tutorial/mc-files/mc-run.jl
@@ -13,20 +13,21 @@ model = platform.models[:nameless]
 mcscn1 = Scenario(
   model,
   (0., 200.);
-  parameters = [:k1=>0.01]
+  parameters = [:k1=>0.01],
+  saveat = [50., 80., 150.]
 )
 
 mcscn2 = Scenario(
   model,
   (0., 200.);
-  parameters = [:k1=>0.02]
+  parameters = [:k1=>0.02],
+  saveat = [50., 100., 200.]
 )
 
 mcsim1 = mc(
   mcscn1,
   [:k1=>Uniform(1e-3,1e-2), :k2=>Normal(1e-3,1e-4), :k3=>Normal(1e-4,1e-5)],
-  100,
-  saveat = [50., 80., 150.]
+  100
 )
 
 plotd = plot(mcsim1, vars=[:b])
@@ -39,8 +40,7 @@ mc_df1 = DataFrame(mcsim1, vars=[:a, :b])
 mcsim2 = mc(
   [:mc1=>mcscn1,:mc2=>mcscn2],
   [:k1=>0.01, :k2=>Normal(1e-3,1e-4), :k3=>Uniform(1e-4,1e-2)],
-  100,
-  saveat = [50., 100., 200.]
+  100
 )
 plotd = plot(mcsim2)
 # savefig(plotd,"file.png")

--- a/docs/src/tutorial/mc-files/scenarios.csv
+++ b/docs/src/tutorial/mc-files/scenarios.csv
@@ -1,5 +1,5 @@
-id,parameters.k1,parameters.k2,parameters.k3,tspan,observables[],events_active.sw1
-one,,0.001,0.02,150,,1
-two,0.001,,,150,,TRUE
-three,1.00E-03,0.1,,250,,
-four,1.00E-04,,0.2,1000,b;c,
+id,parameters.k1,parameters.k2,parameters.k3,saveat[],tspan,observables[],events_active.sw1
+one,,0.001,0.02,0;12;24;48;72;120,150,,1
+two,0.001,,,0;12;24;48;72;120,,,TRUE
+three,1.00E-03,0.1,,,250,,
+four,1.00E-04,,0.2,,1000,b;c,

--- a/docs/src/tutorial/mc.md
+++ b/docs/src/tutorial/mc.md
@@ -74,13 +74,15 @@ Create two scenarios as follows.
 mcscn1 = Scenario(
   model,
   (0., 200.);
-  parameters = [:k1=>0.01]
+  parameters = [:k1=>0.01],
+  saveat = [50., 80., 150.]
 )
 
 mcscn2 = Scenario(
   model,
   (0., 200.);
-  parameters = [:k1=>0.02]
+  parameters = [:k1=>0.02],
+  saveat = [50., 100., 200.]
 )
 ```
 
@@ -94,7 +96,7 @@ You can also set the `Float64` value of a parameter here and this rewrites the v
 The third argument is the number of Monte-Carlo simulations to do.
 
 ```julia
-mcsim1 = mc(mcscn1, [:k1=>Uniform(1e-3,1e-2), :k2=>Normal(1e-3,1e-4), :k3=>Normal(1e-4,1e-5)], 100,  saveat = [50., 80., 150.])
+mcsim1 = mc(mcscn1, [:k1=>Uniform(1e-3,1e-2), :k2=>Normal(1e-3,1e-4), :k3=>Normal(1e-4,1e-5)], 100)
 ```
 
 We can limit the components for visualization with `vars` argument in `plot`.
@@ -264,6 +266,6 @@ plot(ens)
 
 ## Final remarks
 
-1. If you are going to use "statistics" methods you should always set the `saveat` argument in `mc`.
+1. If you are going to use "statistics" methods you should always set the `saveat` argument in `Scenario`.
 
 1. If you run `mc` with parameters generated online, i.e. without pre-generated set currently you cannot obtain the input parameters values directly.  This will be fixed in one of future releases. Before that if you need them use pre-generation.

--- a/docs/src/tutorial/sim-files/sim-run.jl
+++ b/docs/src/tutorial/sim-files/sim-run.jl
@@ -16,8 +16,8 @@ scenario0 = Scenario(model, (0, 10); events_active = [:sw1=>false])
 res0 = sim(scenario0)
 plot(res0)
 
-scenario0 = Scenario(model, (0, 10); events_active = [:sw1=>false])
-res0 = sim(scenario0, saveat = [1, 4, 10])
+scenario0 = Scenario(model, (0, 10); saveat = [1, 4, 10], events_active = [:sw1=>false])
+res0 = sim(scenario0)
 plot(res0)
 
 # update dose

--- a/src/HetaSimulator.jl
+++ b/src/HetaSimulator.jl
@@ -59,11 +59,11 @@ module HetaSimulator
   export read_scenarios, add_scenarios!
   export read_measurements, add_measurements!, measurements_as_table
   export read_parameters
-  export models, scenarios, constants, records, switchers, events, parameters, events_active, events_save, observables  # variables, dynamic, static
+  export models, scenarios, scenario, constants, records, switchers, events, parameters, events_active, events_save, observables  # variables, dynamic, static
   export measurements, tspan 
   export CVODE_BDF, CVODE_Adams
   export optim, obj
-  export sim, mc
+  export sim, mc, mc!
   export fit, loss, estimator
   export HetaSimulatorDir
   export update

--- a/src/monte_carlo.jl
+++ b/src/monte_carlo.jl
@@ -329,10 +329,10 @@ function mc(
 end
 
 """
-    mc!(mcres::MCResult; 
+    mc!(mcres::M; 
       success_status::Vector{Symbol}=[:Success,:Terminated]
       kwargs...
-    )
+    ) where M <: Union{MCResult, Vector{MCResult}, Vector{Pair}}
 
 Re-run failed Monte-Carlo simulations with single `Scenario`. Updates `MCResult` type.
 
@@ -354,6 +354,14 @@ function mc!(mcres::MCResult; success_status::Vector{Symbol}=[:Success,:Terminat
   end
   return nothing
 end
+
+function mc!(mcres::Vector{M}; kwargs...) where M<:MCResult
+  for mcr in mcres
+    mc!(mcr; kwargs...)
+  end
+end
+
+mc!(mcres::Vector{P}; kwargs...) where P<:Pair = mc!(last.(mcres); kwargs...)
 
 
 

--- a/src/monte_carlo.jl
+++ b/src/monte_carlo.jl
@@ -356,7 +356,7 @@ function mc!(mcres::MCResult; success_status::Vector{Symbol}=[:Success,:Terminat
   err_idxs = [i for i in 1:length(mcres) if status(mcres[i]) ∉ success_status]
   mcvecs = DataFrame([NamedTuple(parameters(mcres[i])) for i in err_idxs])
   mcres_upd = mc(scen, mcvecs; kwargs...)
-  for i in eachindex(ids)
+  for i in eachindex(err_idxs)
     mcres.sim[err_idxs[i]] = mcres_upd[i]
   end
   return nothing

--- a/src/monte_carlo.jl
+++ b/src/monte_carlo.jl
@@ -354,7 +354,7 @@ Arguments:
 function mc!(mcres::MCResult; success_status::Vector{Symbol}=[:Success,:Terminated], kwargs...)
   scen = scenario(mcres)
   err_idxs = [i for i in 1:length(mcres) if status(mcres[i]) ∉ success_status]
-  mcvecs = DataFrame([parameters(mcres[i]) for i in err_idxs], collect(keys(parameters(mcres[i]))))
+  mcvecs = DataFrame([parameters(mcres[i]) for i in err_idxs], collect(keys(parameters(mcres[err_idxs[1]]))))
   mcres_upd = mc(scen, mcvecs; kwargs...)
   for i in eachindex(ids)
     mcres.sim[err_idxs[i]] = mcres_upd[i]

--- a/src/monte_carlo.jl
+++ b/src/monte_carlo.jl
@@ -354,7 +354,7 @@ Arguments:
 function mc!(mcres::MCResult; success_status::Vector{Symbol}=[:Success,:Terminated], kwargs...)
   scen = scenario(mcres)
   err_idxs = [i for i in 1:length(mcres) if status(mcres[i]) ∉ success_status]
-  mcvecs = DataFrame([parameters(mcres[i]) for i in err_idxs], collect(keys(parameters(mcres[err_idxs[1]]))))
+  mcvecs = DataFrame([NamedTuple(parameters(mcres[i])) for i in err_idxs])
   mcres_upd = mc(scen, mcvecs; kwargs...)
   for i in eachindex(ids)
     mcres.sim[err_idxs[i]] = mcres_upd[i]

--- a/src/monte_carlo.jl
+++ b/src/monte_carlo.jl
@@ -13,7 +13,6 @@ DEFAULT_OUTPUT(sol,i) = sol
       alg=DEFAULT_ALG,
       reltol=DEFAULT_SIMULATION_RELTOL,
       abstol=DEFAULT_SIMULATION_ABSTOL,
-      saveat=Float64[],
       parallel_type=EnsembleSerial(),
       kwargs...
     )
@@ -32,7 +31,6 @@ Arguments:
 - `alg` : ODE solver. See SciML docs for details. Default is AutoTsit5(Rosenbrock23())
 - `reltol` : relative tolerance. Default is 1e-3
 - `abstol` : relative tolerance. Default is 1e-6
-- `saveat` : time points to save the solution at. Default is solver stepwise saving
 - `output_func` : the function determines what is saved from the solution to the output array. Defaults to saving the solution itself
 - `reduction_func` : this function determines how to reduce the data in each batch. Defaults to appending the data from the batches
 - `parallel_type` : parallel setup. See SciML docs for details. Default is no parallelism: EnsembleSerial()
@@ -47,14 +45,13 @@ function mc(
   alg=DEFAULT_ALG,
   reltol=DEFAULT_SIMULATION_RELTOL,
   abstol=DEFAULT_SIMULATION_ABSTOL,
-  saveat=Float64[],
   output_func=DEFAULT_OUTPUT,
   reduction_func = DEFAULT_REDUCTION,
   parallel_type=EnsembleSerial(),
   kwargs...
 ) where P<:Pair
 
-  prob0 = !isempty(saveat) ? remake_saveat(scenario.prob, saveat) : scenario.prob
+  prob0 = scenario.prob
   init_func = scenario.init_func
   params_nt = NamedTuple(params)
 
@@ -109,7 +106,7 @@ function mc(
     )
   end
 
-  return MCResult(solution.u, !isempty(saveat), scenario)
+  return MCResult(solution.u, has_saveat(scenario), scenario)
 end
 
 """
@@ -158,7 +155,6 @@ end
       alg=DEFAULT_ALG,
       reltol=DEFAULT_SIMULATION_RELTOL,
       abstol=DEFAULT_SIMULATION_ABSTOL,
-      saveat=Float64[],
       parallel_type=EnsembleSerial(),
       kwargs...
     )
@@ -177,7 +173,6 @@ Arguments:
 - `alg` : ODE solver. See SciML docs for details. Default is AutoTsit5(Rosenbrock23())
 - `reltol` : relative tolerance. Default is 1e-3
 - `abstol` : relative tolerance. Default is 1e-6
-- `saveat` : time points to save the solution at. Default is solver stepwise saving
 - `output_func` : the function determines what is saved from the solution to the output array. Defaults to saving the solution itself
 - `reduction_func` : this function determines how to reduce the data in each batch. Defaults to appending the data from the batches
 - `parallel_type` : parallel setup. See SciML docs for details. Default is no parallelism: EnsembleSerial()
@@ -192,7 +187,6 @@ function mc(
   alg=DEFAULT_ALG,
   reltol=DEFAULT_SIMULATION_RELTOL,
   abstol=DEFAULT_SIMULATION_ABSTOL,
-  saveat=Float64[],
   output_func=DEFAULT_OUTPUT,
   reduction_func = DEFAULT_REDUCTION,
   parallel_type=EnsembleSerial(),
@@ -206,13 +200,12 @@ function mc(
   iter = collect(Iterators.product(1:lp,1:lc))
 
   p = Progress(num_iter, dt=0.5, barglyphs=BarGlyphs("[=> ]"), barlen=50, enabled=progress_bar)
-  prob_vec = !isempty(saveat) ? [remake_saveat(last(sc).prob,saveat) for sc in scenario_pairs] : [last(sc).prob for sc in scenario_pairs]
   
   function prob_func(prob,i,repeat)
     iter_i = iter[i]
     verbose && println("Processing scenario $(iter_i[2]) iteration $(iter_i[1])")
     progress_bar && (parallel_type != EnsembleDistributed() ? next!(p) : put!(progch, true))
-    prob_i = prob_vec[iter_i[2]]
+    prob_i = last(scenario_pairs[iter_i[2]]).prob
     init_i = last(scenario_pairs[iter_i[2]]).init_func
     update_init_values(prob_i, init_i, params_pregenerated[iter_i[1]])
   end
@@ -263,7 +256,7 @@ function mc(
 
   for i in 1:lc
     ret[i] = first(scenario_pairs[i]) => 
-      MCResult(solution.u[lp*(i-1)+1:i*lp], !isempty(saveat), last(scenario_pairs[i]))
+    MCResult(solution.u[lp*(i-1)+1:i*lp], has_saveat(last(scenario_pairs[i])), last(scenario_pairs[i]))
   end
   return ret
 end
@@ -336,7 +329,7 @@ function mc(
 end
 
 """
-    mc(mcres::MCResult; 
+    mc!(mcres::MCResult; 
       success_status::Vector{Symbol}=[:Success,:Terminated]
       kwargs...
     )
@@ -347,7 +340,7 @@ Example: `mc!(mcres)`
 
 Arguments:
 
-- `mcres` : platform of [`Platform`](@ref) type
+- `mcres` : Monte-Carlo result of type `MCResult`
 - `success_status` : Vector of success statuses. Default is `[:Success,:Terminated]`
 - kwargs : other solver related arguments supported by `mc(scenario::Scenario, params::Vector, num_iter::Int64)`
 """
@@ -368,9 +361,8 @@ end
 
 # currently median and quantile don't output LVector
 
-function DiffEqBase.EnsembleAnalysis.get_timestep(mcr::MCResult, i) 
+function DiffEqBase.EnsembleAnalysis.get_timestep(mcr::MCResult,i) 
   @assert has_saveat(mcr) "Solution doesn't contain single time vector, default statistics are not available."
-
   return (getindex(mcr[j],i) for j in 1:length(mcr))
 end
 

--- a/src/monte_carlo.jl
+++ b/src/monte_carlo.jl
@@ -335,6 +335,35 @@ function mc(
   return mc(scenario_pairs,params,num_iter;kwargs...)
 end
 
+"""
+    mc(mcres::MCResult; 
+      success_status::Vector{Symbol}=[:Success,:Terminated]
+      kwargs...
+    )
+
+Re-run failed Monte-Carlo simulations with single `Scenario`. Updates `MCResult` type.
+
+Example: `mc!(mcres)`
+
+Arguments:
+
+- `mcres` : platform of [`Platform`](@ref) type
+- `success_status` : Vector of success statuses. Default is `[:Success,:Terminated]`
+- kwargs : other solver related arguments supported by `mc(scenario::Scenario, params::Vector, num_iter::Int64)`
+"""
+function mc!(mcres::MCResult; success_status::Vector{Symbol}=[:Success,:Terminated], kwargs...)
+  scen = scenario(mcres)
+  err_idxs = [i for i in 1:length(mcres) if status(mcres[i]) ∉ success_status]
+  mcvecs = DataFrame([parameters(mcres[i]) for i in err_idxs], collect(keys(parameters(mcres[i]))))
+  mcres_upd = mc(scen, mcvecs; kwargs...)
+  for i in eachindex(ids)
+    mcres.sim[err_idxs[i]] = mcres_upd[i]
+  end
+  return nothing
+end
+
+
+
 ########################################## Statistics ######################################################
 
 # currently median and quantile don't output LVector

--- a/src/ode_problem.jl
+++ b/src/ode_problem.jl
@@ -5,10 +5,12 @@ function build_ode_problem(
   events_active::Union{Nothing, Vector{Pair{Symbol,Bool}}} = Pair{Symbol,Bool}[],
   events_save::Union{Tuple,Vector{Pair{Symbol, Tuple{Bool, Bool}}}} = (true,true), 
   observables_::Union{Nothing,Vector{Symbol}} = nothing,
+  saveat::Union{Nothing,AbstractVector} = nothing,
   save_scope::Bool = true,
   time_type::DataType = Float64
 )
-
+  
+  _saveat = isnothing(saveat) ? time_type[] : saveat 
   # initial values and params
   init_func = model.init_func
   parameters_nt = NamedTuple(parameters)
@@ -33,7 +35,7 @@ function build_ode_problem(
     save_scope ? Symbol[] : nothing
     )
   saving_func = model.saving_generator(merged_observables)
-  scb = saving_wrapper(saving_func, saved_values; save_scope)
+  scb = saving_wrapper(saving_func, saved_values; saveat=_saveat, save_scope)
 
   # events
   ev_on_nt = !isnothing(events_active) ? NamedTuple(events_active) : NamedTuple()

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -1,6 +1,8 @@
 const CONSTANT_PREFIX = "parameters"
 const SWITCHER_PREFIX = "events_active"
 const SWITCHER_SAVE_PREFIX = "events_save"
+const SAVEAT_HEADER = Symbol("saveat[]")
+
 const TSPAN_HEADER = Symbol("tspan")
 const OBSERVABLES_HEADER = Symbol("observables[]")
 const TAGS_HEADER = Symbol("tags[]")
@@ -15,7 +17,9 @@ const GROUP_HEADER = Symbol("group")
       observables::Union{Nothing,Vector{Symbol}}=nothing,
       parameters::Vector{Pair{Symbol,Float64}} = Pair{Symbol,Float64}[],
       events_active::Union{Nothing, Vector{Pair{Symbol,Bool}}} = Pair{Symbol,Bool}[],
-      events_save::Union{Tuple,Vector{Pair{Symbol, Tuple{Bool, Bool}}}} = (true,true), 
+      events_save::Union{Tuple,Vector{Pair{Symbol, Tuple{Bool, Bool}}}} = (true,true),
+      saveat::Union{Nothing,AbstractVector} = nothing,
+
       save_scope::Bool = true,
     )
 
@@ -34,6 +38,8 @@ Arguments:
 - `parameters` : `Vector` of `Pair`s containing constants' names and values. Overwrites default model's values. Default is empty vector.
 - `events_active` : `Vector` of `Pair`s containing events' names and true/false values. Overwrites default model's values. Default is empty `Vector{Pair}`
 - `events_save` : `Tuple` or `Vector{Tuple}` marking whether to save solution before and after event. Default is `(true,true)` for all events
+- `saveat` : time points, where solution should be saved. Default `nothing` values stands for saving solution at timepoints reached by the solver 
+
 - `save_scope` : should scope be saved together with solution. Default is `true`
 """
 function Scenario(
@@ -133,6 +139,13 @@ function _add_scenario!(platform::Platform, row::Any) # maybe not any
     end
   end
   
+  if haskey(row, SAVEAT_HEADER) && !ismissing(row[SAVEAT_HEADER])
+    save_times = row[SAVEAT_HEADER]
+    _saveat = typeof(save_times) <: Number ? [Float64(save_times)] : parse.(Float64, split(save_times, ";"))
+  else  
+    _saveat = nothing
+  end
+  
   if haskey(row, TSPAN_HEADER) && !ismissing(row[TSPAN_HEADER])
     _tspan = (0., row[TSPAN_HEADER])
   else  
@@ -167,6 +180,7 @@ function _add_scenario!(platform::Platform, row::Any) # maybe not any
     parameters = _parameters,
     events_active = _events_active,
     events_save = _events_save,
+    saveat = _saveat,
     observables = _observables,
     tags = _tags,
     group = _group

--- a/src/types.jl
+++ b/src/types.jl
@@ -325,6 +325,7 @@ end
 parameters(mcr::MCResult) = [parameters(mcr[i]) for i in 1:length(mcr)]
 vals(mcr::MCResult) = [vals(mcr[i]) for i in 1:length(mcr)]
 status_summary(mcr::MCResult) = counter([s.status for s in mcr.sim])
+scenario(mcres::MCResult) = mcres.scenario
 
 function Base.show(io::IO, mime::MIME"text/plain", mcr::MCResult{Vector{S},C}, short::Bool = false) where {S<:Simulation, C}
   # dimentions

--- a/src/types.jl
+++ b/src/types.jl
@@ -160,6 +160,7 @@ struct Scenario{F,P,M} <: AbstractScenario
   group::Union{Symbol,Nothing}
 end 
 
+saveat(scn::Scenario) = scn.prob.kwargs[:callback].discrete_callbacks[1].affect!.saveat_cache
 tspan(scn::Scenario) = scn.prob.tspan
 parameters(scn::Scenario) = scn.prob.p.constants
 measurements(scn::Scenario) = scn.measurements

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -33,6 +33,7 @@ function _subset(
   end
 end
 
+has_saveat(c::Scenario) = has_saveat(c.prob)
 has_saveat(prob::SciMLBase.AbstractODEProblem) = !isempty(prob.kwargs[:callback].discrete_callbacks[1].affect!.saveat_cache) 
 has_saveat(mcr::MCResult) = mcr.saveat
 

--- a/test/single_comp_test.jl
+++ b/test/single_comp_test.jl
@@ -12,7 +12,7 @@ model = platform.models[:nameless];
 @test_throws ErrorException("The following observables have not been found in the model: [:GG]") Scenario(model, (0,120); observables=[:r1, :GG])
 
 # Simulate default scenario
-s = sim(Scenario(model, (0., 200.), observables=[:r1]), saveat = [0.0, 150., 250.])
+s = sim(Scenario(model, (0., 200.), observables=[:r1], saveat = [0.0, 150., 250.]))
 @test test_show(s)
 @test typeof(s) <: HetaSimulator.SimResult
 @test status(s) == :Success
@@ -21,7 +21,7 @@ s = sim(Scenario(model, (0., 200.), observables=[:r1]), saveat = [0.0, 150., 250
 
 # tests related to saveat, tspan behavior
 s1 = Scenario(model, (0., 200.)) |> sim
-s2 = sim(Scenario(model, (0,250)), saveat = [150., 200.])
+s2 = sim(Scenario(model, (0,250); saveat = [150., 200.]))
 @test times(s1)[1] == 0.0
 @test times(s1)[end] == 200.0
 @test times(s2) == [150., 200.]
@@ -37,7 +37,7 @@ scn2 = Scenario(model, (0., 150.); parameters = [:k1=>0.015], observables=[:r1])
 @test parameters(scn2)[:k1] == 0.015
 
 cs1 = sim(scn1)
-cs2 = sim([:one=>scn1,:two=>scn2], parameters_upd=[:k1=>0.03], saveat= [0.,100.,120.])
+cs2 = sim([:one=>scn1,:two=>scn2], parameters_upd=[:k1=>0.03])
 @test typeof(cs1) <: HetaSimulator.SimResult
 @test typeof(cs2) <: Vector{Pair{Symbol, HetaSimulator.SimResult}}
 @test length(parameters(cs1))==0
@@ -81,7 +81,7 @@ fscn2 = Scenario(model, (0., 200.); parameters = [:k1=>0.015], observables=[:A, 
 data = read_measurements("$HetaSimulatorDir/test/examples/single_comp/single_comp_data.csv")
 add_measurements!(fscn1, data; subset = [:scenario => :one])
 add_measurements!(fscn2, data; subset = [:scenario => :two])
-fres = fit([:one=>fscn1, :two=>fscn2], [:k1=>0.01], silent=true)
+fres = fit([:one=>fscn1, :two=>fscn2], [:k1=>0.01], progress=:silent)
 
 @test typeof(fres) <: HetaSimulator.FitResult
 @test test_show(fres)


### PR DESCRIPTION
PR contains the following changes:
- `saveat` kwarg moved to `Scenario` from `sim`, `mc` functions. `tspan` remains the mandatory arg in `Scenario`
- re-simulation methods mc! are added for `MCResult, Vector{MCResult}, Vector{Pair}`