### PR TITLE
Fix: update params in simulation result during fitting

### DIFF
--- a/src/HetaSimulator.jl
+++ b/src/HetaSimulator.jl
@@ -37,6 +37,7 @@ module HetaSimulator
   using DataStructures
   @reexport using NaNMath
   @reexport using DataFrames
+  import DataFrames: DataFrame
   @reexport using Distributions
   using LinearAlgebra
   using Distributed

--- a/src/estimator.jl
+++ b/src/estimator.jl
@@ -96,16 +96,18 @@ function estimator(
     end
   end
 
-  function _output(sol, i)
-    if !SciMLBase.successful_retcode(sol.retcode)
-      @warn "Simulated scenario $i returned $(sol.retcode) status"
-      return (Inf, false)
+  function output_func(x)
+    function(sol, i)
+      if !SciMLBase.successful_retcode(sol.retcode)
+        @warn "Simulated scenario $i returned $(sol.retcode) status"
+        return (Inf, false)
+      end
+      sv = sol.prob.kwargs[:callback].discrete_callbacks[1].affect!.saved_values
+      simulation = Simulation(sv, NamedTuple{Tuple(parameters_fitted_names)}(x), sol.retcode)
+      result = SimResult(simulation, last(selected_scenario_pairs[i]))
+      loss_val = loss(result, result.scenario.measurements)
+      (loss_val, false)
     end
-    sv = sol.prob.kwargs[:callback].discrete_callbacks[1].affect!.saved_values
-    simulation = Simulation(sv, NamedTuple(parameters_fitted_norm), sol.retcode)
-    result = SimResult(simulation, last(selected_scenario_pairs[i]))
-    loss_val = loss(result, result.scenario.measurements)
-    (loss_val, false)
   end
 
   function _reduction(u, batch, I)
@@ -115,7 +117,7 @@ function estimator(
   prob(x) = EnsembleProblem(
     EMPTY_PROBLEM;
     prob_func = prob_func(x),
-    output_func = _output,
+    output_func = output_func(x),
     reduction = _reduction,
     safetycopy=false
   )

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -5,7 +5,7 @@ const DEFAULT_FITTING_ABSTOL = 1e-8
 
 """
     fit(
-      scenario_pairs::AbstractVector{Pair{Symbol, C}},
+      scenario_pairs,
       parameters_fitted::AbstractVector{<:Pair{Symbol,<:Real}};
       parameters::Union{Nothing, Vector{P}}=nothing,
       alg=DEFAULT_ALG,
@@ -23,7 +23,7 @@ const DEFAULT_FITTING_ABSTOL = 1e-8
       scale = fill(:lin, length(parameters_fitted)),
       progress::Symbol = :minimal,
       kwargs... 
-    ) where {C<:AbstractScenario, P<:Pair}
+    ) where {P<:Pair}
 
   Fit parameters to experimental measurements. Returns `FitResult` type.
 
@@ -70,7 +70,7 @@ function fit(
   scale = fill(:lin, length(parameters_fitted)),
   progress::Symbol = :minimal,
   kwargs... # other arguments to sim
-) where {C<:AbstractScenario, P<:Pair}
+) where {P<:Pair}
 
   optprob = generate_optimization_problem(
     scenario_pairs,

--- a/test/single_comp_test.jl
+++ b/test/single_comp_test.jl
@@ -104,6 +104,6 @@ fres = fit([:one=>fscn1, :two=>fscn2], [:k1=>0.01, :sigma1=>1.0], progress=:sile
 @test length(measurements(fscn1)) == 24
 @test length(measurements(fscn2)) == 24
 @test status(fres) == :Success
-@test isapprox(obj(fres), 146.05; atol=1e-2)
+@test isapprox(obj(fres), 88.57; atol=1e-2)
 @test typeof(optim(fres)) == Vector{Pair{Symbol, Float64}}
 @test length(optim(fres)) == 2

--- a/test/single_comp_test.jl
+++ b/test/single_comp_test.jl
@@ -107,3 +107,4 @@ fres = fit([:one=>fscn1, :two=>fscn2], [:k1=>0.01, :sigma1=>1.0], progress=:sile
 @test isapprox(obj(fres), 88.57; atol=1e-2)
 @test typeof(optim(fres)) == Vector{Pair{Symbol, Float64}}
 @test length(optim(fres)) == 2
+@test isapprox(last(optim(fres))[2], 0.002; atol=1e-3)


### PR DESCRIPTION
PR fixes the issue when objective parameters (mean, std) are fitted together with model parameters. At each iteration of the optimizer all parameter values should be updated in Simulation object